### PR TITLE
Fix for UserExistsAction

### DIFF
--- a/Frends.LDAP.AddUserToGroups/Frends.LDAP.AddUserToGroups/AddUserToGroups.cs
+++ b/Frends.LDAP.AddUserToGroups/Frends.LDAP.AddUserToGroups/AddUserToGroups.cs
@@ -42,7 +42,7 @@ public class LDAP
         }
         catch (LdapException ex)
         {
-            if (ex.Message.Equals("Attribute Or Value Exists") && input.UserExistsAction.Equals(UserExistsAction.Skip)) 
+            if (ex.Message.Equals("Entry Already Exists") && input.UserExistsAction.Equals(UserExistsAction.Skip)) 
                 return new Result(false, ex.Message, input.UserDistinguishedName, input.GroupDistinguishedName);
             else
                 throw new Exception($"AddUserToGroups LDAP error: {ex.Message}");


### PR DESCRIPTION
Corrects the message returned from LdapException in order to return a Result object with Success = false. Currently the task just returns a System.Exception which is not ideal. We want a proper Result object so that we can act on the Success bool. 