### PR TITLE
LDAP.SearchObjects - Fixed issue with AttributeSet

### DIFF
--- a/Frends.LDAP.SearchObjects/CHANGELOG.md
+++ b/Frends.LDAP.SearchObjects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.0] - 2025-01-02
+### Fixed
+- Fixed issue with AttributeSet not having all values that were returned from LDAP search.
+
 ## [2.0.0] - 2024-11-06
 ### Added
 - [Breaking] Added parameter for AnonymousBind to enable to connect without credentials.

--- a/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects.Tests/UnitTests.cs
+++ b/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects.Tests/UnitTests.cs
@@ -439,7 +439,7 @@ public class UnitTests
         conn.Connect(_host, _port);
         conn.Bind(_user, _pw);
 
-        foreach(var i in _cns)
+        foreach (var i in _cns)
         {
             var title = i.Contains("Qwe Rty") ? "Coffee maker" : "engineer";
             LdapAttributeSet attributeSet = new();

--- a/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects.Tests/UnitTests.cs
+++ b/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects.Tests/UnitTests.cs
@@ -64,14 +64,13 @@ public class UnitTests
 
         var result = LDAP.SearchObjects(input, connection, default);
         Assert.IsTrue(result.Success.Equals(true));
+
         Assert.IsTrue(result.SearchResult.Any(x =>
             x.DistinguishedName.Equals("CN=Tes Tuser,ou=users,dc=wimpi,dc=net") &&
             x.AttributeSet.Any(y => y.Key.Equals("sn")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Tuser")) &&
             x.AttributeSet.Any(y => y.Key.Equals("cn")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Tes Tuser")) &&
-            x.AttributeSet.Any(y => y.Key.Equals("objectclass")) &&
-            x.AttributeSet.Any(y => y.Value.Equals("top")) &&
             x.AttributeSet.Any(y => y.Key.Equals("givenname")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Te")) &&
             x.AttributeSet.Any(y => y.Key.Equals("title")) &&
@@ -110,8 +109,6 @@ public class UnitTests
             x.AttributeSet.Any(y => y.Value.Equals("Tuser")) &&
             x.AttributeSet.Any(y => y.Key.Equals("cn")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Tes Tuser")) &&
-            x.AttributeSet.Any(y => y.Key.Equals("objectclass")) &&
-            x.AttributeSet.Any(y => y.Value.Equals("top")) &&
             x.AttributeSet.Any(y => y.Key.Equals("givenname")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Te")) &&
             x.AttributeSet.Any(y => y.Key.Equals("title")) &&
@@ -150,8 +147,6 @@ public class UnitTests
             x.AttributeSet.Any(y => y.Value.Equals("Tuser")) &&
             x.AttributeSet.Any(y => y.Key.Equals("cn")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Tes Tuser")) &&
-            x.AttributeSet.Any(y => y.Key.Equals("objectclass")) &&
-            x.AttributeSet.Any(y => y.Value.Equals("top")) &&
             x.AttributeSet.Any(y => y.Key.Equals("givenname")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Te")) &&
             x.AttributeSet.Any(y => y.Key.Equals("title")) &&
@@ -190,8 +185,6 @@ public class UnitTests
             x.AttributeSet.Any(y => y.Value.Equals("Tuser")) &&
             x.AttributeSet.Any(y => y.Key.Equals("cn")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Tes Tuser")) &&
-            x.AttributeSet.Any(y => y.Key.Equals("objectclass")) &&
-            x.AttributeSet.Any(y => y.Value.Equals("top")) &&
             x.AttributeSet.Any(y => y.Key.Equals("givenname")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Te")) &&
             x.AttributeSet.Any(y => y.Key.Equals("title")) &&
@@ -230,8 +223,6 @@ public class UnitTests
             x.AttributeSet.Any(y => y.Value.Equals("Tuser")) &&
             x.AttributeSet.Any(y => y.Key.Equals("cn")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Tes Tuser")) &&
-            x.AttributeSet.Any(y => y.Key.Equals("objectclass")) &&
-            x.AttributeSet.Any(y => y.Value.Equals("top")) &&
             x.AttributeSet.Any(y => y.Key.Equals("givenname")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Te")) &&
             x.AttributeSet.Any(y => y.Key.Equals("title")) &&
@@ -270,8 +261,6 @@ public class UnitTests
             x.AttributeSet.Any(y => y.Value.Equals("Tuser")) &&
             x.AttributeSet.Any(y => y.Key.Equals("cn")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Tes Tuser")) &&
-            x.AttributeSet.Any(y => y.Key.Equals("objectclass")) &&
-            x.AttributeSet.Any(y => y.Value.Equals("top")) &&
             x.AttributeSet.Any(y => y.Key.Equals("givenname")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Te")) &&
             x.AttributeSet.Any(y => y.Key.Equals("title")) &&
@@ -384,8 +373,6 @@ public class UnitTests
             x.AttributeSet.Any(y => y.Value.Equals("Tuser")) &&
             x.AttributeSet.Any(y => y.Key.Equals("cn")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Tes Tuser")) &&
-            x.AttributeSet.Any(y => y.Key.Equals("objectclass")) &&
-            x.AttributeSet.Any(y => y.Value.Equals("top")) &&
             x.AttributeSet.Any(y => y.Key.Equals("givenname")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Te")) &&
             x.AttributeSet.Any(y => y.Key.Equals("title")) &&
@@ -433,8 +420,6 @@ public class UnitTests
         Assert.IsFalse(result.SearchResult.Any(x =>
             x.AttributeSet.Any(y => y.Key.Equals("sn")) ||
             x.AttributeSet.Any(y => y.Value.Equals("Tes Tuser")) &&
-            x.AttributeSet.Any(y => y.Key.Equals("objectclass")) &&
-            x.AttributeSet.Any(y => y.Value.Equals("top")) &&
             x.AttributeSet.Any(y => y.Key.Equals("givenname")) &&
             x.AttributeSet.Any(y => y.Value.Equals("Te")) &&
             x.AttributeSet.Any(y => y.Key.Equals("title")) &&

--- a/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects/Definitions/Connection.cs
+++ b/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects/Definitions/Connection.cs
@@ -37,7 +37,7 @@ public class Connection
     /// </summary>
     /// <example>V2</example>
     [DefaultValue(LDAPVersion.V3)]
-    public LDAPVersion LDAPProtocolVersion {  get; set; } 
+    public LDAPVersion LDAPProtocolVersion { get; set; }
 
     /// <summary>
     /// If enabled credentials are not used to create a bind to the LDAP server.

--- a/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects/Definitions/SearchResult.cs
+++ b/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects/Definitions/SearchResult.cs
@@ -32,5 +32,5 @@ public class AttributeSet
     /// <summary>
     /// Value.
     /// </summary>
-    public string Value { get; set; }
+    public dynamic Value { get; set; }
 }

--- a/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects.csproj
+++ b/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>2.0.0</Version>
+	<Version>2.1.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects/SearchObjects.cs
+++ b/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects/SearchObjects.cs
@@ -4,6 +4,7 @@ using Novell.Directory.Ldap;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Linq;
 
 namespace Frends.LDAP.SearchObjects;
 
@@ -91,7 +92,8 @@ public class LDAP
                     {
                         LdapAttribute attribute = ienum.Current;
                         var attributeName = attribute.Name;
-                        var attributeVal = attribute.StringValue;
+
+                        dynamic attributeVal = attribute.StringValueArray.Length <= 1 ? attribute.StringValue : attribute.StringValueArray;
                         attributeList.Add(new AttributeSet { Key = attributeName, Value = attributeVal });
                     }
 

--- a/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects/SearchObjects.cs
+++ b/Frends.LDAP.SearchObjects/Frends.LDAP.SearchObjects/SearchObjects.cs
@@ -31,16 +31,16 @@ public class LDAP
         var atr = new List<string>();
         var searchResults = new List<SearchResult>();
         var searchConstraints = new LdapSearchConstraints(
-                input.MsLimit, 
-                input.ServerTimeLimit, 
-                SetSearchDereference(input), 
+                input.MsLimit,
+                input.ServerTimeLimit,
+                SetSearchDereference(input),
                 input.MaxResults,
                 false,
                 input.BatchSize,
                 null,
                 0);
-        
-        if(input.Attributes != null)
+
+        if (input.Attributes != null)
             foreach (var i in input.Attributes)
                 atr.Add(i.Key.ToString());
 
@@ -68,12 +68,12 @@ public class LDAP
                 conn.Bind(version: ldapVersion, connection.User, connection.Password);
 
             LdapSearchQueue queue = conn.Search(
-                input.SearchBase, 
-                SetScope(input), 
+                input.SearchBase,
+                SetScope(input),
                 input.Filter,
-                atr.ToArray(), 
-                input.TypesOnly, 
-                null, 
+                atr.ToArray(),
+                input.TypesOnly,
+                null,
                 searchConstraints);
 
             LdapMessage message;


### PR DESCRIPTION
#22 

## [2.1.0] - 2025-01-02
### Fixed
- Fixed issue with AttributeSet not having all values that were returned from LDAP search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the module to version 2.1.0 with enhanced flexibility in handling LDAP search results, now properly capturing all attribute values.

- **Bug Fixes**
  - Resolved an issue where LDAP searches returned incomplete attribute data.

- **Documentation**
  - Refreshed release notes and supporting documentation to reflect the latest updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->