### PR TITLE
Fixed bug with empty groups

### DIFF
--- a/Frends.LDAP.AddUserToGroups/Frends.LDAP.AddUserToGroups/AddUserToGroups.cs
+++ b/Frends.LDAP.AddUserToGroups/Frends.LDAP.AddUserToGroups/AddUserToGroups.cs
@@ -43,7 +43,7 @@ public class LDAP
 
             if (UserExistsInGroup(conn, input.UserDistinguishedName, input.GroupDistinguishedName, cancellationToken) && input.UserExistsAction.Equals(UserExistsAction.Skip))
                 return new Result(false, "AddUserToGroups LDAP error: User already exists in the group.", input.UserDistinguishedName, input.GroupDistinguishedName);
-
+            
             conn.Modify(input.GroupDistinguishedName, mods);
 
             return new Result(true, null, input.UserDistinguishedName, input.GroupDistinguishedName);
@@ -62,7 +62,7 @@ public class LDAP
             conn.Disconnect();
         }
     }
-
+   
     private static bool UserExistsInGroup(LdapConnection connection, string userDn, string groupDn, CancellationToken cancellationToken)
     {
         // Search for the user's groups
@@ -90,12 +90,17 @@ public class LDAP
             if (entry != null)
             {
                 LdapAttribute memberAttr = entry.GetAttribute("member");
-                var currentMembers = memberAttr.StringValueArray;
-                if (currentMembers.Where(e => e == userDn).Any())
+                //Check that the attribute exists, otherwise an error will be thrown if the group is empty.
+                if(memberAttr != null)
+                {
+                    var currentMembers = memberAttr.StringValueArray;
+                    if (currentMembers.Where(e => e == userDn).Any())
                     return true;
+                }
+                return false;
             }
         }
-
+        
         return false;
     }
 }


### PR DESCRIPTION
Fixed issue where the member attribute could not be found if the LDAP group was empty, leading to a System.Collections.Generic.KeyNotFoundException. This issue was mentioned by my colleague in [this issue](https://github.com/FrendsPlatform/Frends.LDAP/issues/19).

The fix introduces a conditional check into the UserExistsInGroup function to make sure the "member" attribute is not null before checking if a user is already part of the LDAP group. If the attribute is null, the function assumes no user exists, returns false and  the task continues as normal.

This PR was created on behalf of the Municipality of Skövde Kommun. If you have any questions, please contact me at oscar.j.andersson@skovde.se

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when checking group membership by preventing errors if a group has no members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->